### PR TITLE
Lock the builder until the campaign is complete

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,6 +4,7 @@ import GameMap from "./Map";
 import Heart from "./Heart";
 import Builder from "./Builder";
 import BuilderOverview from "./BuilderOverview";
+import BuilderLocked from "./BuilderLocked";
 import FallbackInstall from "./FallbackInstall";
 import InvalidShareMessage from "./InvalidShareMessage";
 import BlasterExplanation from "./BlasterExplanation";
@@ -101,6 +102,11 @@ export default function App() {
     case "builderOverview":
       componentToRender = (
         <BuilderOverview setDisplay={setDisplay}></BuilderOverview>
+      );
+      break;
+    case "builderLocked":
+      componentToRender = (
+        <BuilderLocked setDisplay={setDisplay}></BuilderLocked>
       );
       break;
     case "customShare":

--- a/src/components/BuilderLocked.js
+++ b/src/components/BuilderLocked.js
@@ -1,0 +1,21 @@
+import React from "react";
+
+export default function BuilderLocked({setDisplay}) {
+  return (
+    <div className="App customMessage">
+      <p className="infoText">
+        Complete the campaign to build your own puzzles to share with friends!
+      </p>
+      <div id="custom-message-buttons">
+        <button
+          className="textButton"
+          onClick={() => {
+            setDisplay("game");
+          }}
+        >
+          Ok
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ControlBar.js
+++ b/src/components/ControlBar.js
@@ -2,6 +2,8 @@ import React from "react";
 import {handleInstall} from "../common/handleInstall";
 import packageJson from "../../package.json";
 import Share from "./Share";
+import {useGameContext} from "./GameContextProvider";
+import {campaignIsCompleteQ} from "../logic/campaignIsCompleteQ";
 
 function ControlBar({
   setDisplay,
@@ -9,6 +11,9 @@ function ControlBar({
   installPromptEvent,
   setInstallPromptEvent,
 }) {
+  const {completedLevels} = useGameContext();
+  const campaignIsComplete = campaignIsCompleteQ(completedLevels);
+
   return (
     <div id="controls">
       <button
@@ -46,7 +51,11 @@ function ControlBar({
       <button
         id="builderIcon"
         className="controlButton"
-        onClick={() => setDisplay("builderOverview")}
+        onClick={() =>
+          campaignIsComplete
+            ? setDisplay("builderOverview")
+            : setDisplay("builderLocked")
+        }
       ></button>
 
       <small id="rulesVersion">version {packageJson.version}</small>


### PR DESCRIPTION
Players can't access the builder until they complete the campaign. This way, they aren't exposed to puzzle elements that won't make sense until later campaign levels, and they get a reward for finishing the campaign.